### PR TITLE
Add auto-fetch on launch

### DIFF
--- a/LCEMonitorApp/LCEMonitorApp.swift
+++ b/LCEMonitorApp/LCEMonitorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LebanonCountryEmergencyMonitorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/LCEMonitorApp/Model/DispatchEvent.swift
+++ b/LCEMonitorApp/Model/DispatchEvent.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct DispatchEvent: Identifiable, Codable {
+    let id: UUID
+    let title: String
+    let detail: String
+
+    init(id: UUID = UUID(), title: String, detail: String) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+    }
+}

--- a/LCEMonitorApp/Services/MonitorService.swift
+++ b/LCEMonitorApp/Services/MonitorService.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftUI
+
+final class MonitorService: ObservableObject {
+    @Published var events: [DispatchEvent] = []
+    private var timer: Timer?
+    private let storageKey = "savedEvents"
+
+    init() {
+        loadSavedEvents()
+        start()
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        fetch()
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.fetch()
+        }
+    }
+
+    private func fetch() {
+        guard let url = URL(string: "https://www.lcdes.org/monitor.html") else { return }
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            guard let data = data, error == nil else { return }
+            if let html = String(data: data, encoding: .utf8) {
+                let parsed = self.parseHTML(html)
+                DispatchQueue.main.async {
+                    self.events = parsed
+                    self.saveEvents(parsed)
+                }
+            }
+        }
+        task.resume()
+    }
+
+    private func parseHTML(_ html: String) -> [DispatchEvent] {
+        // Simple naive parsing; adjust depending on site structure
+        var results: [DispatchEvent] = []
+        let lines = html.components(separatedBy: "\n")
+        for line in lines {
+            if line.contains("<tr") {
+                // Extract pieces between <td> tags as sample
+                let parts = line.components(separatedBy: "<td>")
+                if parts.count > 1 {
+                    var entries: [String] = []
+                    for part in parts.dropFirst() {
+                        if let end = part.range(of: "</td>") {
+                            let value = String(part[..<end.lowerBound])
+                                .replacingOccurrences(of: "&nbsp;", with: " ")
+                                .trimmingCharacters(in: .whitespacesAndNewlines)
+                            entries.append(value)
+                        }
+                    }
+                    if let first = entries.first {
+                        let rest = entries.dropFirst().joined(separator: " ")
+                        results.append(DispatchEvent(title: first, detail: rest))
+                    }
+                }
+            }
+        }
+        return results
+    }
+
+    private func saveEvents(_ events: [DispatchEvent]) {
+        if let data = try? JSONEncoder().encode(events) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    private func loadSavedEvents() {
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let saved = try? JSONDecoder().decode([DispatchEvent].self, from: data) {
+            self.events = saved
+        }
+    }
+}

--- a/LCEMonitorApp/Views/ContentView.swift
+++ b/LCEMonitorApp/Views/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var service = MonitorService()
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if service.events.isEmpty {
+                    ProgressView("Loading...")
+                } else {
+                    List(service.events) { event in
+                        VStack(alignment: .leading) {
+                            Text(event.title)
+                                .font(.headline)
+                            Text(event.detail)
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Lebanon Country Emergency Monitor")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ReadMe
+++ b/ReadMe
@@ -1,1 +1,10 @@
-Repo for LCEMonitor App
+# Lebanon Country Emergency Monitor
+
+The Lebanon Country Emergency Monitor app fetches dispatch information from the Lebanon County Emergency Services website.
+
+## Building
+
+Open the project in Xcode (iOS 17 or later) and run `LebanonCountryEmergencyMonitorApp` on an iOS device or simulator. The app polls `https://www.lcdes.org/monitor.html` every 30 seconds and displays the parsed events in a list.
+
+On launch the app immediately fetches the current monitor page and persists the events so previous results appear the next time you open the app.
+


### PR DESCRIPTION
## Summary
- fetch events immediately when the service is created
- guard against creating multiple timers
- tidy ContentView
- clarify ReadMe about persistence

## Testing
- `swiftc LCEMonitorApp/LCEMonitorApp.swift -o /tmp/app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6881026ef4bc83278c3254a847c29f5d