### PR TITLE
Parse full dispatch info

### DIFF
--- a/LCEMonitorApp/LCEMonitorApp.swift
+++ b/LCEMonitorApp/LCEMonitorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LebanonCountyEmergencyMonitorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/LCEMonitorApp/Model/DispatchEvent.swift
+++ b/LCEMonitorApp/Model/DispatchEvent.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct DispatchEvent: Identifiable, Codable {
+    let id: UUID
+    let time: String
+    let date: String
+    let message: String
+    let location: String
+
+    init(id: UUID = UUID(), time: String, date: String, message: String, location: String) {
+        self.id = id
+        self.time = time
+        self.date = date
+        self.message = message
+        self.location = location
+    }
+}

--- a/LCEMonitorApp/Services/MonitorService.swift
+++ b/LCEMonitorApp/Services/MonitorService.swift
@@ -1,0 +1,84 @@
+import Foundation
+import SwiftUI
+
+final class MonitorService: ObservableObject {
+    @Published var events: [DispatchEvent] = []
+    @Published var isLoading: Bool = false
+    private var timer: Timer?
+    private let storageKey = "savedEvents"
+
+    init() {
+        loadSavedEvents()
+        start()
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        fetch()
+        timer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.fetch()
+        }
+    }
+
+    private func fetch() {
+        guard let url = URL(string: "https://www.lcdes.org/monitor.html") else { return }
+        DispatchQueue.main.async { self.isLoading = true }
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            defer {
+                DispatchQueue.main.async { self.isLoading = false }
+            }
+            guard let data = data, error == nil else { return }
+            if let html = String(data: data, encoding: .utf8) {
+                let parsed = self.parseHTML(html)
+                DispatchQueue.main.async {
+                    self.events = parsed
+                    self.saveEvents(parsed)
+                }
+            }
+        }
+        task.resume()
+    }
+
+    private func parseHTML(_ html: String) -> [DispatchEvent] {
+        var parsed: [DispatchEvent] = []
+        let rowRegex = try? NSRegularExpression(pattern: "<tr[^>]*>(.*?)</tr>", options: [.caseInsensitive, .dotMatchesLineSeparators])
+        let cellRegex = try? NSRegularExpression(pattern: "<td[^>]*>(.*?)</td>", options: [.caseInsensitive, .dotMatchesLineSeparators])
+
+        let htmlRange = NSRange(location: 0, length: html.utf16.count)
+        rowRegex?.enumerateMatches(in: html, options: [], range: htmlRange) { match, _, _ in
+            guard let match = match else { return }
+            let rowHTML = (html as NSString).substring(with: match.range(at: 1))
+            let rowRange = NSRange(location: 0, length: rowHTML.utf16.count)
+            var cells: [String] = []
+            cellRegex?.enumerateMatches(in: rowHTML, options: [], range: rowRange) { cellMatch, _, _ in
+                guard let cellMatch = cellMatch else { return }
+                var cell = (rowHTML as NSString).substring(with: cellMatch.range(at: 1))
+                cell = cell.replacingOccurrences(of: "&nbsp;", with: " ")
+                cell = cell.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                cell = cell.trimmingCharacters(in: .whitespacesAndNewlines)
+                cells.append(cell)
+            }
+
+            if cells.count >= 4 {
+                let header = cells[0].lowercased()
+                if header.contains("time") && cells[1].lowercased().contains("date") { return }
+                let event = DispatchEvent(time: cells[0], date: cells[1], message: cells[2], location: cells[3])
+                parsed.append(event)
+            }
+        }
+        return parsed
+    }
+
+    private func saveEvents(_ events: [DispatchEvent]) {
+        if let data = try? JSONEncoder().encode(events) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    private func loadSavedEvents() {
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let saved = try? JSONDecoder().decode([DispatchEvent].self, from: data) {
+            self.events = saved
+        }
+    }
+}

--- a/LCEMonitorApp/Views/ContentView.swift
+++ b/LCEMonitorApp/Views/ContentView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var service = MonitorService()
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if service.isLoading && service.events.isEmpty {
+                    ProgressView("Loading...")
+                } else if service.events.isEmpty {
+                    Text("No events available")
+                        .foregroundColor(.secondary)
+                } else {
+                    List(service.events) { event in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("\(event.date) \(event.time)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Text(event.message)
+                                .font(.headline)
+                            Text(event.location)
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Lebanon County Emergency Monitor")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ReadMe
+++ b/ReadMe
@@ -1,1 +1,11 @@
-Repo for LCEMonitor App
+# Lebanon County Emergency Monitor
+
+The Lebanon County Emergency Monitor app fetches dispatch information from the Lebanon County Emergency Services website.
+
+## Building
+
+Open the project in Xcode (iOS 17 or later) and run `LebanonCountyEmergencyMonitorApp` on an iOS device or simulator. The app polls `https://www.lcdes.org/monitor.html` every 30 seconds and displays the parsed events in a list.
+
+The HTML parser extracts the time, date, message, and location from each dispatch row.
+On launch the app immediately fetches the current monitor page and persists the events so previous results appear the next time you open the app. If the fetch fails, the app shows a "No events available" message rather than an endless loading indicator.
+


### PR DESCRIPTION
## Summary
- rename app to **Lebanon County Emergency Monitor**
- parse the monitor page for time, date, message and location
- show each field in the main list view
- document the parsing behavior in the README

## Testing
- `swiftc LCEMonitorApp/LCEMonitorApp.swift -o /tmp/app` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6881026ef4bc83278c3254a847c29f5d